### PR TITLE
Use shared action for audit instead of workflow

### DIFF
--- a/.github/workflows/audit-renovate-config.yml
+++ b/.github/workflows/audit-renovate-config.yml
@@ -5,4 +5,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: coveo/public-actions/audit-renovate-config@CIA-583/audit-renovate-config
+      - uses: coveo/public-actions/audit-renovate-config@main

--- a/.github/workflows/audit-renovate-config.yml
+++ b/.github/workflows/audit-renovate-config.yml
@@ -2,4 +2,7 @@ name: Audit Renovate Config
 on: pull_request
 jobs:
   check:
-    uses: coveo-platform/renovate/.github/workflows/_audit-renovate-config.yml@main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: coveo/public-actions/audit-renovate-config@CIA-583/audit-renovate-config

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @coveooss/dev-tooling @coveooss/cloud-intelligence


### PR DESCRIPTION
This PR switched up our approach. Instead of using a shared workflow from our renovate project, we use a shared action in our public actions repo instead. This allows this to work for both public and private repos.