### PR TITLE
chore: remove cloud intelligence from code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @coveooss/dev-tooling @coveooss/cloud-intelligence
+* @coveooss/dev-tooling


### PR DESCRIPTION
We used to have a renovate workflow in here but it's gone and we no longer own renovate so we don't really belong here anymore.